### PR TITLE
feat: add observability #5

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -310,6 +310,92 @@ The tree node.
 
 ## Structs <a name="Structs" id="Structs"></a>
 
+### AlarmProps <a name="AlarmProps" id="serverless-website-analytics.AlarmProps"></a>
+
+#### Initializer <a name="Initializer" id="serverless-website-analytics.AlarmProps.Initializer"></a>
+
+```typescript
+import { AlarmProps } from 'serverless-website-analytics'
+
+const alarmProps: AlarmProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#serverless-website-analytics.AlarmProps.property.alarmTopic">alarmTopic</a></code> | <code>aws-cdk-lib.aws_sns.Topic</code> | The SNS topic to send alarms to. |
+| <code><a href="#serverless-website-analytics.AlarmProps.property.alarmTypes">alarmTypes</a></code> | <code><a href="#serverless-website-analytics.AlarmTypes">AlarmTypes</a></code> | Specify which alarms you want. |
+
+---
+
+##### `alarmTopic`<sup>Required</sup> <a name="alarmTopic" id="serverless-website-analytics.AlarmProps.property.alarmTopic"></a>
+
+```typescript
+public readonly alarmTopic: Topic;
+```
+
+- *Type:* aws-cdk-lib.aws_sns.Topic
+
+The SNS topic to send alarms to.
+
+---
+
+##### `alarmTypes`<sup>Required</sup> <a name="alarmTypes" id="serverless-website-analytics.AlarmProps.property.alarmTypes"></a>
+
+```typescript
+public readonly alarmTypes: AlarmTypes;
+```
+
+- *Type:* <a href="#serverless-website-analytics.AlarmTypes">AlarmTypes</a>
+
+Specify which alarms you want.
+
+---
+
+### AlarmTypes <a name="AlarmTypes" id="serverless-website-analytics.AlarmTypes"></a>
+
+#### Initializer <a name="Initializer" id="serverless-website-analytics.AlarmTypes.Initializer"></a>
+
+```typescript
+import { AlarmTypes } from 'serverless-website-analytics'
+
+const alarmTypes: AlarmTypes = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#serverless-website-analytics.AlarmTypes.property.firehose">firehose</a></code> | <code>boolean</code> | Adds a throttle and s3 delivery failure alarms for both Firehoses. |
+| <code><a href="#serverless-website-analytics.AlarmTypes.property.lambda">lambda</a></code> | <code>boolean</code> | Adds a hard and soft alarm to both Lambda functions; |
+
+---
+
+##### `firehose`<sup>Required</sup> <a name="firehose" id="serverless-website-analytics.AlarmTypes.property.firehose"></a>
+
+```typescript
+public readonly firehose: boolean;
+```
+
+- *Type:* boolean
+
+Adds a throttle and s3 delivery failure alarms for both Firehoses.
+
+---
+
+##### `lambda`<sup>Required</sup> <a name="lambda" id="serverless-website-analytics.AlarmTypes.property.lambda"></a>
+
+```typescript
+public readonly lambda: boolean;
+```
+
+- *Type:* boolean
+
+Adds a hard and soft alarm to both Lambda functions;
+
+---
+
 ### AwsEnv <a name="AwsEnv" id="serverless-website-analytics.AwsEnv"></a>
 
 The AWS environment (account and region) to deploy to.
@@ -433,6 +519,49 @@ Optional, if specified, it adds tracking to the dashboard.
 
 This is useful if you want to see the usage of
 the serverless-website-analytics dashboard page.
+
+---
+
+### Observability <a name="Observability" id="serverless-website-analytics.Observability"></a>
+
+#### Initializer <a name="Initializer" id="serverless-website-analytics.Observability.Initializer"></a>
+
+```typescript
+import { Observability } from 'serverless-website-analytics'
+
+const observability: Observability = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#serverless-website-analytics.Observability.property.alarms">alarms</a></code> | <code><a href="#serverless-website-analytics.AlarmProps">AlarmProps</a></code> | Adds CloudWatch Alarms to the resources created by this construct. |
+| <code><a href="#serverless-website-analytics.Observability.property.dashboard">dashboard</a></code> | <code>boolean</code> | Adds a CloudWatch dashboard with metrics for the resources created by this construct. |
+
+---
+
+##### `alarms`<sup>Optional</sup> <a name="alarms" id="serverless-website-analytics.Observability.property.alarms"></a>
+
+```typescript
+public readonly alarms: AlarmProps;
+```
+
+- *Type:* <a href="#serverless-website-analytics.AlarmProps">AlarmProps</a>
+
+Adds CloudWatch Alarms to the resources created by this construct.
+
+---
+
+##### `dashboard`<sup>Optional</sup> <a name="dashboard" id="serverless-website-analytics.Observability.property.dashboard"></a>
+
+```typescript
+public readonly dashboard: boolean;
+```
+
+- *Type:* boolean
+
+Adds a CloudWatch dashboard with metrics for the resources created by this construct.
 
 ---
 
@@ -648,6 +777,7 @@ const swaProps: SwaProps = { ... }
 | <code><a href="#serverless-website-analytics.SwaProps.property.auth">auth</a></code> | <code><a href="#serverless-website-analytics.SwaAuth">SwaAuth</a></code> | The auth configuration which defaults to none. |
 | <code><a href="#serverless-website-analytics.SwaProps.property.domain">domain</a></code> | <code><a href="#serverless-website-analytics.Domain">Domain</a></code> | If specified, it will create the CloudFront and Cognito resources at the specified domain and optionally create the DNS records in the specified Route53 hosted zone. |
 | <code><a href="#serverless-website-analytics.SwaProps.property.isDemoPage">isDemoPage</a></code> | <code>boolean</code> | If specified, adds the banner at the top of the page linking back to the open source project. |
+| <code><a href="#serverless-website-analytics.SwaProps.property.observability">observability</a></code> | <code><a href="#serverless-website-analytics.Observability">Observability</a></code> | Adds a CloudWatch Dashboard and Alarms if specified. |
 
 ---
 
@@ -749,6 +879,18 @@ public readonly isDemoPage: boolean;
 - *Type:* boolean
 
 If specified, adds the banner at the top of the page linking back to the open source project.
+
+---
+
+##### `observability`<sup>Optional</sup> <a name="observability" id="serverless-website-analytics.SwaProps.property.observability"></a>
+
+```typescript
+public readonly observability: Observability;
+```
+
+- *Type:* <a href="#serverless-website-analytics.Observability">Observability</a>
+
+Adds a CloudWatch Dashboard and Alarms if specified.
 
 ---
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -94,8 +94,8 @@ export function auth(scope: Construct, name: (name: string) => string, props: Sw
         },
       });
       userPoolDomain = domain.baseUrl();
-      new cdk.CfnOutput(scope, name('COGNITO_HOSTED_UI_URL'), {
-        description: 'COGNITO_HOSTED_UI_URL',
+      new cdk.CfnOutput(scope, name('CognitoHostedUrl'), {
+        description: 'Cognito Hosted Url',
         value: userPoolDomain,
       });
     } else {
@@ -118,9 +118,12 @@ export function auth(scope: Construct, name: (name: string) => string, props: Sw
       });
     }
 
-    new cdk.CfnOutput(scope, name('USER_POOL_ID'), { description: 'USER_POOL_ID', value: userPool.userPoolId });
-    new cdk.CfnOutput(scope, name('USER_POOL_CLIENT_ID'), {
-      description: 'USER_POOL_CLIENT_ID',
+    new cdk.CfnOutput(scope, name('CognitoUserPoolId'), {
+      description: 'Cognito UserPoolId',
+      value: userPool.userPoolId,
+    });
+    new cdk.CfnOutput(scope, name('CognitoUserPoolClientId'), {
+      description: 'Cognito UserPool ClientId',
       value: userPoolClient.userPoolClientId,
     });
   } else {

--- a/src/backendAnalytics.ts
+++ b/src/backendAnalytics.ts
@@ -9,6 +9,7 @@ import { CfnLogGroup } from 'aws-cdk-lib/aws-logs';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
 import { SwaProps } from './index';
+import { CwBucket, CwFirehose } from './lib/cloudwatch-helper';
 
 export function backendAnalytics(scope: Construct, name: (name: string) => string, props: SwaProps) {
   /* ======================================================================= */
@@ -464,22 +465,25 @@ export function backendAnalytics(scope: Construct, name: (name: string) => strin
   firehoseEvents.addDependency(firehoseDeliveryRole.node.defaultChild as CfnRole);
   firehoseEvents.addDependency(logGroup.node.defaultChild as CfnLogGroup);
 
-  new cdk.CfnOutput(scope, name('ANALYTICS_BUCKET'), {
-    description: 'ANALYTICS_BUCKET',
+  new cdk.CfnOutput(scope, name('AnalyticsBucket'), {
+    description: 'Analytics Bucket',
     value: analyticsBucket.bucketName,
   });
-  new cdk.CfnOutput(scope, name('FIREHOSE_PAGE_VIEWS_NAME'), {
-    description: 'FIREHOSE_PAGE_VIEWS_NAME',
+  new cdk.CfnOutput(scope, name('FirehosePageViewsName'), {
+    description: 'Firehose Page Views Name',
     value: firehosePageViews.deliveryStreamName!,
   });
-  new cdk.CfnOutput(scope, name('FIREHOSE_EVENTS_NAME'), {
-    description: 'FIREHOSE_EVENTS_NAME',
+  new cdk.CfnOutput(scope, name('FirehoseEventsName'), {
+    description: 'Firehose Events Name',
     value: firehoseEvents.deliveryStreamName!,
   });
-  new cdk.CfnOutput(scope, name('ANALYTICS_GLUE_DB_NAME'), {
-    description: 'ANALYTICS_GLUE_DB_NAME',
+  new cdk.CfnOutput(scope, name('AnalyticsGlueDbName'), {
+    description: 'Analytics Glue DB Name',
     value: glueDbName,
   });
+
+  const cwBuckets: CwBucket[] = [{ bucket: analyticsBucket }];
+  const cwFirehoses: CwFirehose[] = [{ firehose: firehosePageViews }, { firehose: firehoseEvents }];
 
   return {
     glueDbName,
@@ -488,5 +492,9 @@ export function backendAnalytics(scope: Construct, name: (name: string) => strin
     analyticsBucket,
     firehosePageViews,
     firehoseEvents,
+    observability: {
+      cwBuckets,
+      cwFirehoses,
+    },
   };
 }

--- a/src/lib/cloudwatch-helper/alarms.ts
+++ b/src/lib/cloudwatch-helper/alarms.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cloudwatchactions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import { Construct } from 'constructs';
+import { CwFirehose, CwLambda } from './index';
+import { CwMetrics } from './metrics';
+
+function metricToAlarmId(scope: Construct, metric: cloudwatch.Metric) {
+  return [scope.node.id, metric.metricName, 'Alarm'].join('-');
+}
+function metricToAlarmName(scope: Construct, metric: cloudwatch.Metric) {
+  return [scope.node.id, metric.namespace, metric.metricName].join('/');
+}
+
+export namespace CwAlarms {
+  export class Lambda {
+    static softError(
+      scope: Construct,
+      cwLambda: CwLambda,
+      cwAlarmAction: cloudwatch.IAlarmAction,
+      cwOkAction?: cloudwatch.IAlarmAction
+    ) {
+      assert.ok(cwLambda.alarm.softErrorFilter);
+
+      const METRIC_NAMESPACE = 'LogMetrics/Lambda';
+      const metricProps: cloudwatch.MetricProps = {
+        namespace: METRIC_NAMESPACE,
+        metricName: 'SoftError',
+        dimensionsMap: { FunctionName: cwLambda.func.functionName },
+        label: cwLambda.func.node.id,
+        period: cdk.Duration.minutes(1),
+        statistic: 'Sum',
+      };
+      const metric = new cloudwatch.Metric(metricProps);
+      const id = [cwLambda.func.node.id, metric.metricName, 'Alarm'].join('-');
+
+      new logs.MetricFilter(scope, id + 'Filter', {
+        metricName: metric.metricName,
+        metricNamespace: metric.namespace,
+        logGroup: cwLambda.func.logGroup,
+        filterPattern: cwLambda.alarm.softErrorFilter,
+        metricValue: '1',
+      });
+      let alarm = new cloudwatch.Alarm(scope, id + 'Alarm', {
+        metric: metric,
+        alarmDescription:
+          'Lambda Soft Error - An error occurred within the function but the invocation still succeeded.',
+        actionsEnabled: true,
+        alarmName: metricToAlarmName(cwLambda.func, metric),
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        threshold: 1,
+        evaluationPeriods: 1,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+      alarm.addAlarmAction(cwAlarmAction);
+      if (cwOkAction) alarm.addOkAction(cwAlarmAction);
+
+      return { alarm, metricProps };
+    }
+
+    static hardError(
+      scope: Construct,
+      cwLambda: CwLambda,
+      cwAlarmAction: cloudwatchactions.SnsAction,
+      cwOkAction?: cloudwatch.IAlarmAction
+    ) {
+      const metric = cwLambda.func.metricErrors({
+        period: cdk.Duration.minutes(1),
+        statistic: 'Sum',
+      });
+
+      let alarm = new cloudwatch.Alarm(scope, metricToAlarmId(cwLambda.func, metric), {
+        metric: cwLambda.func.metricErrors(),
+        alarmDescription: 'Lambda Hard Error - An error occurred and the function invocation failed.',
+        actionsEnabled: true,
+        alarmName: metricToAlarmName(cwLambda.func, metric),
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        threshold: 1,
+        evaluationPeriods: 1,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+      alarm.addAlarmAction(cwAlarmAction);
+      if (cwOkAction) alarm.addOkAction(cwAlarmAction);
+
+      return alarm;
+    }
+  }
+
+  export class Firehose {
+    static deliveryToS3Success(
+      scope: Construct,
+      cwFirehose: CwFirehose,
+      cwAlarmAction: cloudwatch.IAlarmAction,
+      cwOkAction?: cloudwatch.IAlarmAction
+    ) {
+      const metric = CwMetrics.Firehose.deliveryToS3Success(cwFirehose, {
+        period: cdk.Duration.minutes(1),
+      });
+      let alarm = new cloudwatch.Alarm(scope, metricToAlarmId(cwFirehose.firehose, metric), {
+        metric: metric,
+        alarmDescription: 'Firehose Delivery to S3 Error - Not all records delivered to S3, 100% is value 1.0.',
+        actionsEnabled: true,
+        alarmName: metricToAlarmName(cwFirehose.firehose, metric),
+        comparisonOperator: cloudwatch.ComparisonOperator.LESS_THAN_THRESHOLD,
+        threshold: 1,
+        evaluationPeriods: 1,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+      alarm.addAlarmAction(cwAlarmAction);
+      if (cwOkAction) alarm.addOkAction(cwAlarmAction);
+
+      return alarm;
+    }
+
+    static throttleRecords(
+      scope: Construct,
+      cwFirehose: CwFirehose,
+      cwAlarmAction: cloudwatch.IAlarmAction,
+      cwOkAction?: cloudwatch.IAlarmAction
+    ) {
+      const metric = CwMetrics.Firehose.throttleRecords(cwFirehose, {
+        period: cdk.Duration.minutes(1),
+      });
+      let alarm = new cloudwatch.Alarm(scope, metricToAlarmId(cwFirehose.firehose, metric), {
+        metric: metric,
+        alarmDescription: 'Firehose Throttle Error - Not all records have been accepted.',
+        actionsEnabled: true,
+        alarmName: metricToAlarmName(cwFirehose.firehose, metric),
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        threshold: 1,
+        evaluationPeriods: 1,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+      alarm.addAlarmAction(cwAlarmAction);
+      if (cwOkAction) alarm.addOkAction(cwAlarmAction);
+
+      return alarm;
+    }
+  }
+}

--- a/src/lib/cloudwatch-helper/graph-widgets.ts
+++ b/src/lib/cloudwatch-helper/graph-widgets.ts
@@ -1,0 +1,96 @@
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { CwBucket, CwCloudFront, CwFirehose, CwLambda, CwMetrics } from './index';
+
+export namespace CwGraphWidgets {
+  export class S3 {
+    static bucketSize(cwBuckets: CwBucket[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'S3 Bucket Size',
+        left: cwBuckets.map((cwBucket) => CwMetrics.S3.bucketSize(cwBucket)),
+      });
+    }
+    static objectCount(cwBuckets: CwBucket[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'S3 Object Count',
+        left: cwBuckets.map((cwBucket) => CwMetrics.S3.objectCount(cwBucket)),
+      });
+    }
+  }
+
+  export class Firehose {
+    static incomingRecords(cwFirehoses: CwFirehose[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'Firehose Incoming Records',
+        left: cwFirehoses.map((cwFirehose) => CwMetrics.Firehose.incomingRecords(cwFirehose)),
+      });
+    }
+    static deliveryToS3Success(cwFirehoses: CwFirehose[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'Firehose Delivery To S3',
+        left: cwFirehoses.map((cwFirehose) => CwMetrics.Firehose.deliveryToS3Success(cwFirehose)),
+      });
+    }
+  }
+
+  export class CloudFront {
+    static requests(cwCloudFronts: CwCloudFront[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'CloudFront Requests',
+        left: cwCloudFronts.map((cwCloudFront) => CwMetrics.CloudFront.requests(cwCloudFront)),
+      });
+    }
+
+    static errors4xxRate(cwCloudFronts: CwCloudFront[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'CloudFront 4xx Error Rate',
+        left: cwCloudFronts.map((cwCloudFront) => CwMetrics.CloudFront.errors4xxRate(cwCloudFront)),
+      });
+    }
+
+    static errors5xxRate(cwCloudFronts: CwCloudFront[]) {
+      return new cloudwatch.GraphWidget({
+        title: 'CloudFront 5xx Error Rate',
+        left: cwCloudFronts.map((cwCloudFront) => CwMetrics.CloudFront.errors5xxRate(cwCloudFront)),
+      });
+    }
+  }
+
+  export class Logs {
+    static insightsLambdaErrors(
+      accountId: string,
+      lambdaNamePrefix: string,
+      region: string,
+      graphLambdas: CwLambda[]
+    ): cloudwatch.LogQueryWidget {
+      /* The execution log url is double encoded
+         So a $25 is actually becomes % .. ehh  was something like that when I reverse engineered there logic. Here are
+         the charters that need replacing below:
+            $252F is /
+            $255B$2524 is [$
+            $255D is ]
+       */
+      let logNameStartsWith = accountId + ':/aws/lambda/' + lambdaNamePrefix;
+      return new cloudwatch.LogQueryWidget({
+        title: 'Lambda Errors (desc)',
+        logGroupNames: graphLambdas.map((x) => x.func.logGroup.logGroupName),
+        view: cloudwatch.LogQueryVisualizationType.TABLE,
+        width: 24,
+        height: 12,
+        queryString:
+          "fields date, replace(@log, '" +
+          logNameStartsWith +
+          "', '') as Lambda, level, msg, \n" +
+          " concat('https://" +
+          region +
+          '.console.aws.amazon.com/cloudwatch/home?region=' +
+          region +
+          "#logsV2:log-groups/log-group/$252Faws$252Flambda$252F',\n" +
+          " substr(@log, 25), \"/log-events/\", replace(replace(replace (@logStream, '/', '$252F'), '[$' , '$255B$2524'), ']', '$255D'), \n" +
+          " '$3FfilterPattern$3D$2522', traceId, '$2522') as `ExecutionLogsUrl (Triple click, right click open new tab)` \n" +
+          '| filter level == "error" OR level == "warning"  \n' +
+          '| sort @timestamp desc \n' +
+          '| limit 100',
+      });
+    }
+  }
+}

--- a/src/lib/cloudwatch-helper/index.ts
+++ b/src/lib/cloudwatch-helper/index.ts
@@ -1,0 +1,27 @@
+import * as cloudfront from 'aws-cdk-lib/aws-cloudfront';
+import { CfnDeliveryStream } from 'aws-cdk-lib/aws-kinesisfirehose';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+
+export interface CwLambda {
+  alarm: {
+    softErrorFilter?: logs.IFilterPattern;
+    hardError: boolean;
+  };
+  func: lambda.Function;
+}
+
+export interface CwBucket {
+  bucket: s3.Bucket;
+}
+export interface CwFirehose {
+  firehose: CfnDeliveryStream;
+}
+export interface CwCloudFront {
+  distribution: cloudfront.Distribution;
+}
+
+export * from './metrics';
+export * from './alarms';
+export * from './graph-widgets';

--- a/src/lib/cloudwatch-helper/metrics.ts
+++ b/src/lib/cloudwatch-helper/metrics.ts
@@ -1,0 +1,105 @@
+import * as assert from 'assert';
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import { CwBucket, CwCloudFront, CwFirehose } from './index';
+
+export namespace CwMetrics {
+  export class S3 {
+    static bucketSize(cwBucket: CwBucket, props?: Partial<cloudwatch.MetricProps>) {
+      return new cloudwatch.Metric({
+        namespace: 'AWS/S3',
+        label: cwBucket.bucket.bucketName,
+        metricName: 'BucketSizeBytes',
+        dimensionsMap: { BucketName: cwBucket.bucket.bucketName, StorageType: 'StandardStorage' },
+        statistic: 'Maximum',
+        period: cdk.Duration.days(1),
+        ...props,
+      });
+    }
+
+    static objectCount(cwBucket: CwBucket, props?: Partial<cloudwatch.MetricProps>) {
+      return new cloudwatch.Metric({
+        namespace: 'AWS/S3',
+        label: cwBucket.bucket.bucketName,
+        metricName: 'NumberOfObjects',
+        dimensionsMap: { BucketName: cwBucket.bucket.bucketName, StorageType: 'AllStorageTypes' },
+        statistic: 'Maximum',
+        period: cdk.Duration.days(1),
+        ...props,
+      });
+    }
+  }
+  export class Firehose {
+    static incomingRecords(cwFirehose: CwFirehose, props?: Partial<cloudwatch.MetricProps>) {
+      assert.ok(cwFirehose.firehose.deliveryStreamName);
+      return new cloudwatch.Metric({
+        namespace: 'AWS/Firehose',
+        label: cwFirehose.firehose.deliveryStreamName,
+        metricName: 'IncomingRecords',
+        dimensionsMap: { DeliveryStreamName: cwFirehose.firehose.deliveryStreamName },
+        statistic: 'Sum',
+        ...props,
+      });
+    }
+
+    static deliveryToS3Success(cwFirehose: CwFirehose, props?: Partial<cloudwatch.MetricProps>) {
+      assert.ok(cwFirehose.firehose.deliveryStreamName);
+      return new cloudwatch.Metric({
+        namespace: 'AWS/Firehose',
+        label: cwFirehose.firehose.deliveryStreamName,
+        metricName: 'DeliveryToS3.Success',
+        dimensionsMap: { DeliveryStreamName: cwFirehose.firehose.deliveryStreamName },
+        statistic: 'Average',
+        ...props,
+      });
+    }
+
+    static throttleRecords(cwFirehose: CwFirehose, props?: Partial<cloudwatch.MetricProps>) {
+      assert.ok(cwFirehose.firehose.deliveryStreamName);
+      return new cloudwatch.Metric({
+        namespace: 'AWS/Firehose',
+        label: cwFirehose.firehose.deliveryStreamName,
+        metricName: 'ThrottledRecords',
+        dimensionsMap: { DeliveryStreamName: cwFirehose.firehose.deliveryStreamName },
+        statistic: 'Average',
+        ...props,
+      });
+    }
+  }
+
+  export class CloudFront {
+    static requests(cwCloudFront: CwCloudFront, props?: Partial<cloudwatch.MetricProps>) {
+      return new cloudwatch.Metric({
+        region: 'us-east-1',
+        namespace: 'AWS/CloudFront',
+        label: cwCloudFront.distribution.domainName,
+        metricName: 'Requests',
+        dimensionsMap: { Region: 'Global', DistributionId: cwCloudFront.distribution.distributionId },
+        statistic: 'Sum',
+        ...props,
+      });
+    }
+    static errors4xxRate(cwCloudFront: CwCloudFront, props?: Partial<cloudwatch.MetricProps>) {
+      return new cloudwatch.Metric({
+        region: 'us-east-1',
+        namespace: 'AWS/CloudFront',
+        label: cwCloudFront.distribution.domainName,
+        metricName: '4xxErrorRate',
+        dimensionsMap: { Region: 'Global', DistributionId: cwCloudFront.distribution.distributionId },
+        statistic: 'Average',
+        ...props,
+      });
+    }
+    static errors5xxRate(cwCloudFront: CwCloudFront, props?: Partial<cloudwatch.MetricProps>) {
+      return new cloudwatch.Metric({
+        region: 'us-east-1',
+        namespace: 'AWS/CloudFront',
+        label: cwCloudFront.distribution.domainName,
+        metricName: '5xxErrorRate',
+        dimensionsMap: { Region: 'Global', DistributionId: cwCloudFront.distribution.distributionId },
+        statistic: 'Average',
+        ...props,
+      });
+    }
+  }
+}

--- a/src/observability.ts
+++ b/src/observability.ts
@@ -1,0 +1,151 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cloudwatch from 'aws-cdk-lib/aws-cloudwatch';
+import * as cloudwatchactions from 'aws-cdk-lib/aws-cloudwatch-actions';
+import { Construct } from 'constructs';
+import { backend } from './backend';
+import { backendAnalytics } from './backendAnalytics';
+import { frontend } from './frontend';
+import { Observability } from './index';
+import { CwAlarms, CwBucket, CwCloudFront, CwFirehose, CwGraphWidgets, CwLambda } from './lib/cloudwatch-helper';
+
+export function observability(
+  scope: Construct,
+  name: (name: string) => string,
+  account: string,
+  region: string,
+  observabilityProps: Observability,
+  backendAnalyticsProps: ReturnType<typeof backendAnalytics>,
+  backendProps: ReturnType<typeof backend>,
+  frontendProps: ReturnType<typeof frontend>
+) {
+  const cwLambdas: CwLambda[] = [...backendProps.observability.cwLambdas];
+  const cwBuckets: CwBucket[] = [...backendAnalyticsProps.observability.cwBuckets];
+  const cwFirehoses: CwFirehose[] = [...backendAnalyticsProps.observability.cwFirehoses];
+  const cwCloudFronts: CwCloudFront[] = [...frontendProps.observability.cwCloudFronts];
+
+  const cwLambdaSoftErrorGraphMetrics: cloudwatch.Metric[] = [];
+  if (observabilityProps.alarms) {
+    const cwAlarmAction = new cloudwatchactions.SnsAction(observabilityProps.alarms.alarmTopic);
+
+    if (observabilityProps.alarms.alarmTypes.lambda) {
+      for (let cwLambda of cwLambdas) {
+        if (cwLambda.alarm.hardError) CwAlarms.Lambda.hardError(scope, cwLambda, cwAlarmAction);
+        if (cwLambda.alarm?.softErrorFilter) {
+          const { metricProps } = CwAlarms.Lambda.softError(scope, cwLambda, cwAlarmAction);
+          cwLambdaSoftErrorGraphMetrics.push(
+            new cloudwatch.Metric({
+              ...metricProps,
+              label: cwLambda.func.functionName + ' Soft',
+              unit: cloudwatch.Unit.COUNT,
+            })
+          );
+        }
+      }
+    }
+
+    if (observabilityProps.alarms.alarmTypes.firehose) {
+      for (let cwFirehose of cwFirehoses) {
+        CwAlarms.Firehose.throttleRecords(scope, cwFirehose, cwAlarmAction);
+        CwAlarms.Firehose.deliveryToS3Success(scope, cwFirehose, cwAlarmAction);
+      }
+    }
+  }
+
+  if (observabilityProps.dashboard) {
+    const dashboardName = name('dashboard');
+    const dashboard = new cloudwatch.Dashboard(scope, dashboardName, {
+      dashboardName: dashboardName,
+      // start: "-PT24H",
+      start: '-P7D',
+      periodOverride: cloudwatch.PeriodOverride.AUTO,
+    });
+
+    dashboard.addWidgets(
+      new cloudwatch.TextWidget({
+        markdown: '## Lambda Metrics',
+        width: 24,
+        background: cloudwatch.TextWidgetBackground.TRANSPARENT,
+        height: 1,
+      })
+    );
+    dashboard.addWidgets(
+      new cloudwatch.Row(
+        new cloudwatch.GraphWidget({
+          title: cwLambdaSoftErrorGraphMetrics.length ? 'Hard Errors | Soft Errors' : 'Hard Errors',
+          left: cwLambdas.map((cwLambda) =>
+            cwLambda.func.metricErrors({ label: cwLambda.func.functionName + ' Hard' })
+          ),
+          right: cwLambdaSoftErrorGraphMetrics,
+        }),
+        new cloudwatch.GraphWidget({
+          title: 'Invocations',
+          left: cwLambdas.map((cwLambda) => cwLambda.func.metricInvocations({ statistic: 'Sum' })),
+        }),
+        new cloudwatch.GraphWidget({
+          title: 'Throttles',
+          left: cwLambdas.map((cwLambda) => cwLambda.func.metricThrottles({ statistic: 'Maximum' })),
+        }),
+        new cloudwatch.GraphWidget({
+          title: 'Duration',
+          left: cwLambdas.map((cwLambda) => cwLambda.func.metricDuration({ statistic: 'p95' })),
+        })
+      )
+    );
+
+    dashboard.addWidgets(
+      new cloudwatch.TextWidget({
+        markdown: '## S3 & Firehose',
+        width: 24,
+        background: cloudwatch.TextWidgetBackground.TRANSPARENT,
+        height: 1,
+      })
+    );
+    dashboard.addWidgets(
+      new cloudwatch.Row(
+        CwGraphWidgets.S3.bucketSize(cwBuckets),
+        CwGraphWidgets.S3.objectCount(cwBuckets),
+        CwGraphWidgets.Firehose.incomingRecords(cwFirehoses),
+        CwGraphWidgets.Firehose.deliveryToS3Success(cwFirehoses)
+      )
+    );
+
+    dashboard.addWidgets(
+      new cloudwatch.TextWidget({
+        markdown: '## CloudFront',
+        width: 24,
+        background: cloudwatch.TextWidgetBackground.TRANSPARENT,
+        height: 1,
+      })
+    );
+    dashboard.addWidgets(
+      new cloudwatch.Row(
+        CwGraphWidgets.CloudFront.requests(cwCloudFronts),
+        CwGraphWidgets.CloudFront.errors4xxRate(cwCloudFronts),
+        CwGraphWidgets.CloudFront.errors5xxRate(cwCloudFronts)
+      )
+    );
+
+    dashboard.addWidgets(
+      new cloudwatch.TextWidget({
+        markdown: '## Lambda Log Insights',
+        width: 24,
+        background: cloudwatch.TextWidgetBackground.TRANSPARENT,
+        height: 1,
+      })
+    );
+    dashboard.addWidgets(
+      new cloudwatch.Row(CwGraphWidgets.Logs.insightsLambdaErrors(account, name(''), region, cwLambdas))
+    );
+
+    const dashboardUrl =
+      `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#dashboards/` +
+      `dashboard/${dashboardName}`;
+
+    new cdk.CfnOutput(scope, name('DashboardUrl'), {
+      description: 'Dashboard Url',
+      value: dashboardUrl,
+    });
+
+    //https://eu-west-1.console.aws.amazon.com/cloudwatch/home?region=eu-west-1#dashboards/dashboard/rehan-analytics-swa-dashboard
+  }
+}

--- a/test/build.test.ts
+++ b/test/build.test.ts
@@ -1,0 +1,43 @@
+import { App, Stack } from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import { AllAlarmTypes, Swa, SwaProps } from '../src';
+
+test('Local build and debug', () => {
+  const app = new App();
+  const stack = new Stack(app, 'test-build');
+
+  const alarmTopic = new sns.Topic(stack, 'alarm-topic');
+  new Swa(stack, 'testing-swa', {
+    environment: 'dev',
+    awsEnv: {
+      account: '123456789012',
+      region: 'us-east-1',
+    },
+    sites: ['https://example.com'],
+    allowedOrigins: ['https://example.com'],
+    auth: {
+      // basicAuth: {
+      //   username: 'test',
+      //   password: 'test',
+      // },
+      cognito: {
+        loginSubDomain: 'login',
+        users: [
+          {
+            name: 'test',
+            email: 'test@gmail.com',
+          },
+        ],
+      },
+    },
+    observability: {
+      alarms: {
+        alarmTypes: AllAlarmTypes,
+        alarmTopic,
+      },
+      dashboard: true,
+    },
+  });
+  Template.fromStack(stack);
+});


### PR DESCRIPTION
Adds a new `observability` option that allows the creation of:
- A hard + Soft alarm on both Lambdas
- A throttle and S3 delivery alarm on both Firehoses
- A dashboard to monitor Lambdas, S3, Firehose, CloudFront and Show Log Insights for the Lambdas