### PR TITLE
feat: expose lambda concurrency #7 and firehose buffer interval #6

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ export class App extends cdk.Stack {
 Quick option rundown:
 - `sites`: The list of allowed sites. This does not have to be a domain name, it can also be string. It can be anything
   you want to use to identify a site. The client-side script that sends analytics will have to specify one of these names.
+- `firehoseBufferInterval`: The number in seconds for the Firehose buffer interval. The default is 15 minutes (900 seconds), minimum is 60 and
+  maximum is 900.
 - `allowedOrigins`: The origins that are allowed to make requests to the backend Ingest API. This CORS check is done as an extra
   security measure to prevent other sites from making requests to your backend. It must include the protocol and
   full domain. Ex: If your site is `example.com` and it can be accessed using `https://example.com` and
@@ -105,6 +107,7 @@ Quick option rundown:
   CloudFront(`cloudfront.net`) and Cognito(`auth.us-east-1.amazoncognito.com`) domains. You can read the website URL
   from the stack output.
 - `observability`: Adds a CloudWatch Dashboard and Alarms if specified.
+- `rateLimit`: Adds a rate limit to the Ingest API and Frontend/Dashboard API. Defaults to 200 and 100 respectively.
 
 For a full list of options see the [API.md](https://github.com/rehanvdm/serverless-website-analytics/blob/main/docs/API.md#api-reference-) docs.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -597,6 +597,49 @@ Adds a CloudWatch dashboard with metrics for the resources created by this const
 
 ---
 
+### RateLimitProps <a name="RateLimitProps" id="serverless-website-analytics.RateLimitProps"></a>
+
+#### Initializer <a name="Initializer" id="serverless-website-analytics.RateLimitProps.Initializer"></a>
+
+```typescript
+import { RateLimitProps } from 'serverless-website-analytics'
+
+const rateLimitProps: RateLimitProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#serverless-website-analytics.RateLimitProps.property.frontLambdaConcurrency">frontLambdaConcurrency</a></code> | <code>number</code> | The number of concurrent requests to allow on the Front/Dashboard API. |
+| <code><a href="#serverless-website-analytics.RateLimitProps.property.ingestLambdaConcurrency">ingestLambdaConcurrency</a></code> | <code>number</code> | The number of concurrent requests to allow on the Ingest API. |
+
+---
+
+##### `frontLambdaConcurrency`<sup>Required</sup> <a name="frontLambdaConcurrency" id="serverless-website-analytics.RateLimitProps.property.frontLambdaConcurrency"></a>
+
+```typescript
+public readonly frontLambdaConcurrency: number;
+```
+
+- *Type:* number
+
+The number of concurrent requests to allow on the Front/Dashboard API.
+
+---
+
+##### `ingestLambdaConcurrency`<sup>Required</sup> <a name="ingestLambdaConcurrency" id="serverless-website-analytics.RateLimitProps.property.ingestLambdaConcurrency"></a>
+
+```typescript
+public readonly ingestLambdaConcurrency: number;
+```
+
+- *Type:* number
+
+The number of concurrent requests to allow on the Ingest API.
+
+---
+
 ### SwaAuth <a name="SwaAuth" id="serverless-website-analytics.SwaAuth"></a>
 
 The auth configuration which defaults to none.
@@ -808,8 +851,10 @@ const swaProps: SwaProps = { ... }
 | <code><a href="#serverless-website-analytics.SwaProps.property.sites">sites</a></code> | <code>string[]</code> | The list of allowed sites. |
 | <code><a href="#serverless-website-analytics.SwaProps.property.auth">auth</a></code> | <code><a href="#serverless-website-analytics.SwaAuth">SwaAuth</a></code> | The auth configuration which defaults to none. |
 | <code><a href="#serverless-website-analytics.SwaProps.property.domain">domain</a></code> | <code><a href="#serverless-website-analytics.Domain">Domain</a></code> | If specified, it will create the CloudFront and Cognito resources at the specified domain and optionally create the DNS records in the specified Route53 hosted zone. |
+| <code><a href="#serverless-website-analytics.SwaProps.property.firehoseBufferInterval">firehoseBufferInterval</a></code> | <code>number</code> | The number in seconds for the Firehose buffer interval. |
 | <code><a href="#serverless-website-analytics.SwaProps.property.isDemoPage">isDemoPage</a></code> | <code>boolean</code> | If specified, adds the banner at the top of the page linking back to the open source project. |
 | <code><a href="#serverless-website-analytics.SwaProps.property.observability">observability</a></code> | <code><a href="#serverless-website-analytics.Observability">Observability</a></code> | Adds a CloudWatch Dashboard and Alarms if specified. |
+| <code><a href="#serverless-website-analytics.SwaProps.property.rateLimit">rateLimit</a></code> | <code><a href="#serverless-website-analytics.RateLimitProps">RateLimitProps</a></code> | Adds a rate limit to the Ingest API and Frontend/Dashboard API. |
 
 ---
 
@@ -902,6 +947,21 @@ Cognito(`auth.us-east-1.amazoncognito.com`) domains. You can read the website UR
 
 ---
 
+##### `firehoseBufferInterval`<sup>Optional</sup> <a name="firehoseBufferInterval" id="serverless-website-analytics.SwaProps.property.firehoseBufferInterval"></a>
+
+```typescript
+public readonly firehoseBufferInterval: number;
+```
+
+- *Type:* number
+
+The number in seconds for the Firehose buffer interval.
+
+The default is 15 minutes (900 seconds), minimum is 60 and
+maximum is 900.
+
+---
+
 ##### `isDemoPage`<sup>Optional</sup> <a name="isDemoPage" id="serverless-website-analytics.SwaProps.property.isDemoPage"></a>
 
 ```typescript
@@ -923,6 +983,20 @@ public readonly observability: Observability;
 - *Type:* <a href="#serverless-website-analytics.Observability">Observability</a>
 
 Adds a CloudWatch Dashboard and Alarms if specified.
+
+---
+
+##### `rateLimit`<sup>Optional</sup> <a name="rateLimit" id="serverless-website-analytics.SwaProps.property.rateLimit"></a>
+
+```typescript
+public readonly rateLimit: RateLimitProps;
+```
+
+- *Type:* <a href="#serverless-website-analytics.RateLimitProps">RateLimitProps</a>
+
+Adds a rate limit to the Ingest API and Frontend/Dashboard API.
+
+Defaults to 200 and 100 respectively.
 
 ---
 

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -59,7 +59,7 @@ export function backend(
       SITES: JSON.stringify(props.sites),
       ALLOWED_ORIGINS: JSON.stringify(props.allowedOrigins),
     },
-    reservedConcurrentExecutions: 200,
+    reservedConcurrentExecutions: props.rateLimit?.ingestLambdaConcurrency ?? 200,
     layers: [geoLite2Layer],
   });
   apiIngestLambda.addToRolePolicy(
@@ -114,7 +114,7 @@ export function backend(
       TRACK_OWN_DOMAIN: props?.domain?.trackOwnDomain ? 'true' : 'false',
       IS_DEMO_PAGE: props.isDemoPage ? 'true' : 'false',
     },
-    reservedConcurrentExecutions: 100,
+    reservedConcurrentExecutions: props.rateLimit?.frontLambdaConcurrency ?? 100,
   });
   apiFrontLambda.addToRolePolicy(
     new iam.PolicyStatement({

--- a/src/backendAnalytics.ts
+++ b/src/backendAnalytics.ts
@@ -11,6 +11,8 @@ import { Construct } from 'constructs';
 import { SwaProps } from './index';
 import { CwBucket, CwFirehose } from './lib/cloudwatch-helper';
 
+const defaultFirehoseBufferInterval = 900;
+
 export function backendAnalytics(scope: Construct, name: (name: string) => string, props: SwaProps) {
   /* ======================================================================= */
   /* ============ Glue DB, Bucket and Firehose required service  =========== */
@@ -232,7 +234,7 @@ export function backendAnalytics(scope: Construct, name: (name: string) => strin
         'page_views/site=!{partitionKeyFromQuery:site}/year=!{partitionKeyFromQuery:year}/month=!{partitionKeyFromQuery:month}/',
       errorOutputPrefix: 'error/!{firehose:error-output-type}/',
       bufferingHints: {
-        intervalInSeconds: 60,
+        intervalInSeconds: props.firehoseBufferInterval ?? defaultFirehoseBufferInterval,
       },
       dynamicPartitioningConfiguration: {
         enabled: true,
@@ -411,7 +413,7 @@ export function backendAnalytics(scope: Construct, name: (name: string) => strin
         'events/site=!{partitionKeyFromQuery:site}/year=!{partitionKeyFromQuery:year}/month=!{partitionKeyFromQuery:month}/',
       errorOutputPrefix: 'error/!{firehose:error-output-type}/',
       bufferingHints: {
-        intervalInSeconds: 60,
+        intervalInSeconds: props.firehoseBufferInterval ?? defaultFirehoseBufferInterval,
       },
       dynamicPartitioningConfiguration: {
         enabled: true,


### PR DESCRIPTION
Closes #6 and #7 

- The Firehose default is now 15 minutes up from 1 minute
- The ingest Lambda concurrency default stays at 200
- The front/dashboard Lambda concurrency default stays at 100