### PR TITLE
feat: add cron that vacuums data #1

### DIFF
--- a/scripts/index.ts
+++ b/scripts/index.ts
@@ -107,6 +107,7 @@ async function buildTsLambdas()
   const tsLambdaDirectories = [
     "api-front",
     "api-ingest",
+    "cron-vacuum",
   ];
 
   for( let lambdaDir of tsLambdaDirectories)

--- a/src/backend.ts
+++ b/src/backend.ts
@@ -2,10 +2,13 @@ import * as assert from 'assert';
 import * as path from 'path';
 import { Duration } from 'aws-cdk-lib';
 import * as cdk from 'aws-cdk-lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Effect } from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as logs from 'aws-cdk-lib/aws-logs';
+
 import { Construct } from 'constructs';
 import { auth } from './auth';
 import { backendAnalytics } from './backendAnalytics';
@@ -38,7 +41,6 @@ export function backend(
   });
 
   const ingestLambdaTimeout = 10;
-
   const apiIngestLambda = new lambda.Function(scope, name('lambda-api-ingest'), {
     functionName: name('api-ingest'),
     code: lambda.Code.fromAsset(path.join(__dirname, '../lib/build/backend/api-ingest')),
@@ -79,7 +81,7 @@ export function backend(
   /* ============ API Front ========== */
   /* ================================== */
   let frontLambdaTimeOut = 60;
-  let env: Record<string, string> = {
+  let frontLambdaEnv: Record<string, string> = {
     ...defaultEnv,
     TIMEOUT: frontLambdaTimeOut.toString(),
     ENRICH_RETURNED_ERRORS: 'true', //props.environment != "prod"
@@ -93,12 +95,104 @@ export function backend(
     assert.ok(authProps.userPool);
     assert.ok(authProps.userPoolClient);
     assert.ok(authProps.userPoolDomain);
-    env = {
-      ...env,
+    frontLambdaEnv = {
+      ...frontLambdaEnv,
       COGNITO_USER_POOL_ID: authProps.userPool.userPoolId,
       COGNITO_CLIENT_ID: authProps.userPoolClient.userPoolClientId,
       COGNITO_HOSTED_UI_URL: authProps.userPoolDomain,
     };
+  }
+
+  function addAthenaPolicies(func: lambda.IFunction) {
+    func.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'AthenaPermissions',
+        effect: Effect.ALLOW,
+        actions: ['athena:StartQueryExecution', 'athena:GetQueryExecution', 'athena:GetQueryResults'],
+        resources: [
+          cdk.Arn.format({
+            partition: 'aws',
+            account: props.awsEnv.account,
+            region: props.awsEnv.region,
+            service: 'athena',
+            resource: 'workgroup/primary',
+          }),
+        ],
+      })
+    );
+    func.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'GluePermissions',
+        effect: Effect.ALLOW,
+        actions: [
+          'glue:GetTable',
+          'glue:GetTables',
+          'glue:GetPartitions',
+          'glue:BatchCreatePartition',
+          'glue:GetDatabase',
+        ],
+        resources: [
+          cdk.Arn.format({
+            partition: 'aws',
+            account: props.awsEnv.account,
+            region: props.awsEnv.region,
+            service: 'glue',
+            resource: 'catalog',
+          }),
+          cdk.Arn.format({
+            partition: 'aws',
+            account: props.awsEnv.account,
+            region: props.awsEnv.region,
+            service: 'glue',
+            resource: 'database',
+            resourceName: backendAnalyticsProps.glueDbName,
+          }),
+          cdk.Arn.format({
+            partition: 'aws',
+            account: props.awsEnv.account,
+            region: props.awsEnv.region,
+            service: 'glue',
+            resource: 'table',
+            resourceName: backendAnalyticsProps.glueDbName + '/' + backendAnalyticsProps.glueTablePageViewsName,
+          }),
+          cdk.Arn.format({
+            partition: 'aws',
+            account: props.awsEnv.account,
+            region: props.awsEnv.region,
+            service: 'glue',
+            resource: 'table',
+            resourceName: backendAnalyticsProps.glueDbName + '/' + backendAnalyticsProps.glueTableEventsName,
+          }),
+          cdk.Arn.format({
+            partition: 'aws',
+            account: props.awsEnv.account,
+            region: props.awsEnv.region,
+            service: 'glue',
+            resource: 'table',
+            resourceName: backendAnalyticsProps.glueDbName + '/rollup_temp_*',
+          }),
+        ],
+      })
+    );
+    func.addToRolePolicy(
+      new iam.PolicyStatement({
+        sid: 'AthenaS3Permissions',
+        effect: Effect.ALLOW,
+        actions: [
+          's3:GetBucketLocation',
+          's3:GetObject',
+          's3:ListBucket',
+          's3:ListBucketMultipartUploads',
+          's3:ListMultipartUploadParts',
+          's3:AbortMultipartUpload',
+          's3:PutObject',
+        ],
+        resources: [
+          backendAnalyticsProps.analyticsBucket.bucketArn,
+          backendAnalyticsProps.analyticsBucket.arnForObjects('*'),
+        ],
+      })
+    );
   }
 
   const apiFrontLambda = new lambda.Function(scope, name('lambda-api-front'), {
@@ -110,33 +204,50 @@ export function backend(
     memorySize: 1024,
     timeout: Duration.seconds(frontLambdaTimeOut),
     environment: {
-      ...env,
+      ...frontLambdaEnv,
+      ENRICH_RETURNED_ERRORS: 'true', //props.environment != "prod"
+
+      ANALYTICS_BUCKET: backendAnalyticsProps.analyticsBucket.bucketName,
+      ANALYTICS_GLUE_DB_NAME: backendAnalyticsProps.glueDbName,
+      SITES: JSON.stringify(props.sites),
+      TIMEOUT: frontLambdaTimeOut.toString(),
       TRACK_OWN_DOMAIN: props?.domain?.trackOwnDomain ? 'true' : 'false',
       IS_DEMO_PAGE: props.isDemoPage ? 'true' : 'false',
     },
     reservedConcurrentExecutions: props.rateLimit?.frontLambdaConcurrency ?? 100,
   });
-  apiFrontLambda.addToRolePolicy(
+  addAthenaPolicies(apiFrontLambda);
+
+  const apiFrontLambdaUrl = apiFrontLambda.addFunctionUrl({
+    authType: lambda.FunctionUrlAuthType.NONE,
+  });
+
+  const cronVacuumLambdaTimeOut = 900;
+  const cronVacuumLambda = new lambda.Function(scope, name('lambda-cron-vacuum'), {
+    functionName: name('cron-vacuum'),
+    code: lambda.Code.fromAsset(path.join(__dirname, '../lib/build/backend/cron-vacuum')),
+    handler: 'index.handler',
+    runtime: lambda.Runtime.NODEJS_16_X,
+    ...defaultNodeJsFuncOpt,
+    memorySize: 1024,
+    timeout: Duration.seconds(cronVacuumLambdaTimeOut),
+    environment: {
+      ...defaultEnv,
+
+      TIMEOUT: cronVacuumLambdaTimeOut.toString(),
+      ANALYTICS_BUCKET: backendAnalyticsProps.analyticsBucket.bucketName,
+      ANALYTICS_GLUE_DB_NAME: backendAnalyticsProps.glueDbName,
+      SITES: JSON.stringify(props.sites),
+    },
+    /* The lambda is idempotent, retry once */
+    reservedConcurrentExecutions: 1,
+  });
+  addAthenaPolicies(cronVacuumLambda);
+  cronVacuumLambda.addToRolePolicy(
     new iam.PolicyStatement({
-      sid: 'AthenaPermissions',
+      sid: 'RollupPermissionsAthenaGlue',
       effect: Effect.ALLOW,
-      actions: ['athena:StartQueryExecution', 'athena:GetQueryExecution', 'athena:GetQueryResults'],
-      resources: [
-        cdk.Arn.format({
-          partition: 'aws',
-          account: props.awsEnv.account,
-          region: props.awsEnv.region,
-          service: 'athena',
-          resource: 'workgroup/primary',
-        }),
-      ],
-    })
-  );
-  apiFrontLambda.addToRolePolicy(
-    new iam.PolicyStatement({
-      sid: 'GluePermissions',
-      effect: Effect.ALLOW,
-      actions: ['glue:GetTable', 'glue:GetPartitions', 'glue:BatchCreatePartition', 'glue:GetDatabase'],
+      actions: ['glue:CreateTable', 'glue:DeleteTable', 'glue:DeletePartition'],
       resources: [
         cdk.Arn.format({
           partition: 'aws',
@@ -159,41 +270,32 @@ export function backend(
           region: props.awsEnv.region,
           service: 'glue',
           resource: 'table',
-          resourceName: backendAnalyticsProps.glueDbName + '/' + backendAnalyticsProps.glueTablePageViewsName,
+          resourceName: backendAnalyticsProps.glueDbName + '/rollup_temp_*',
         }),
-        cdk.Arn.format({
-          partition: 'aws',
-          account: props.awsEnv.account,
-          region: props.awsEnv.region,
-          service: 'glue',
-          resource: 'table',
-          resourceName: backendAnalyticsProps.glueDbName + '/' + backendAnalyticsProps.glueTableEventsName,
-        }),
-      ],
-    })
-  );
-  apiFrontLambda.addToRolePolicy(
-    new iam.PolicyStatement({
-      sid: 'AthenaS3Permissions',
-      effect: Effect.ALLOW,
-      actions: [
-        's3:GetBucketLocation',
-        's3:GetObject',
-        's3:ListBucket',
-        's3:ListBucketMultipartUploads',
-        's3:ListMultipartUploadParts',
-        's3:AbortMultipartUpload',
-        's3:PutObject',
-      ],
-      resources: [
-        backendAnalyticsProps.analyticsBucket.bucketArn,
-        backendAnalyticsProps.analyticsBucket.arnForObjects('*'),
       ],
     })
   );
 
-  const apiFrontLambdaUrl = apiFrontLambda.addFunctionUrl({
-    authType: lambda.FunctionUrlAuthType.NONE,
+  cronVacuumLambda.addToRolePolicy(
+    new iam.PolicyStatement({
+      sid: 'RollupPermissionsS3Delete',
+      effect: Effect.ALLOW,
+      actions: ['s3:DeleteObject'],
+      resources: [
+        backendAnalyticsProps.analyticsBucket.arnForObjects(
+          'page_views/site=*/page_opened_at_date=*/' + backendAnalyticsProps.firehosePageViews.deliveryStreamName! + '*'
+        ),
+        backendAnalyticsProps.analyticsBucket.arnForObjects(
+          'page_views/site=*/page_opened_at_date=*/' + backendAnalyticsProps.firehoseEvents.deliveryStreamName! + '*'
+        ),
+      ],
+    })
+  );
+
+  /* Executing 1 hour after midnight so that the previous day's data is done writing */
+  new events.Rule(scope, name('cron-vacuum-rule'), {
+    schedule: events.Schedule.cron({ minute: '0', hour: '1' }),
+    targets: [new targets.LambdaFunction(cronVacuumLambda)],
   });
 
   const cwLambdas: CwLambda[] = [
@@ -209,6 +311,16 @@ export function backend(
     },
     {
       func: apiFrontLambda,
+      alarm: {
+        hardError: true,
+        softErrorFilter: logs.FilterPattern.all(
+          logs.FilterPattern.stringValue('$.level', '=', 'audit'),
+          logs.FilterPattern.stringValue('$.success', '=', 'false')
+        ),
+      },
+    },
+    {
+      func: cronVacuumLambda,
       alarm: {
         hardError: true,
         softErrorFilter: logs.FilterPattern.all(

--- a/src/src/backend/api-front/routes/stats/index.ts
+++ b/src/src/backend/api-front/routes/stats/index.ts
@@ -4,6 +4,7 @@ import { SchemaSite } from '@backend/lib/models/site';
 import { DateUtils } from '@backend/lib/utils/date_utils';
 import { AthenaPageViews } from '@backend/lib/dal/athena/page_views';
 import { FilterSchema } from '@backend/lib/models/filter';
+import { LambdaEnvironment } from '@backend/api-front/environment';
 
 const GetTopLevelStatsSchema = z.object({
   visitors: z.number(),
@@ -43,7 +44,10 @@ export function getTopLevelStats(trpcInstance: TrpcInstance) {
 
       if (input.filter && Object.keys(input.filter).length === 0) input.filter = undefined;
 
-      const athenaPageViews = new AthenaPageViews();
+      const athenaPageViews = new AthenaPageViews(
+        LambdaEnvironment.ANALYTICS_GLUE_DB_NAME,
+        LambdaEnvironment.ANALYTICS_BUCKET_ATHENA_PATH
+      );
 
       const fromDate = DateUtils.parseIso(input.from);
       const toDate = DateUtils.parseIso(input.to);
@@ -111,7 +115,10 @@ export function getPageViews(trpcInstance: TrpcInstance) {
 
       if (input.filter && Object.keys(input.filter).length === 0) input.filter = undefined;
 
-      const athenaPageViews = new AthenaPageViews();
+      const athenaPageViews = new AthenaPageViews(
+        LambdaEnvironment.ANALYTICS_GLUE_DB_NAME,
+        LambdaEnvironment.ANALYTICS_BUCKET_ATHENA_PATH
+      );
 
       const fromDate = DateUtils.parseIso(input.from);
       const toDate = DateUtils.parseIso(input.to);
@@ -157,7 +164,10 @@ export function getChartViews(trpcInstance: TrpcInstance) {
 
       if (input.filter && Object.keys(input.filter).length === 0) input.filter = undefined;
 
-      const athenaPageViews = new AthenaPageViews();
+      const athenaPageViews = new AthenaPageViews(
+        LambdaEnvironment.ANALYTICS_GLUE_DB_NAME,
+        LambdaEnvironment.ANALYTICS_BUCKET_ATHENA_PATH
+      );
 
       const fromDate = DateUtils.parseIso(input.from);
       const toDate = DateUtils.parseIso(input.to);
@@ -227,7 +237,10 @@ export function getPageReferrers(trpcInstance: TrpcInstance) {
 
       if (input.filter && Object.keys(input.filter).length === 0) input.filter = undefined;
 
-      const athenaPageViews = new AthenaPageViews();
+      const athenaPageViews = new AthenaPageViews(
+        LambdaEnvironment.ANALYTICS_GLUE_DB_NAME,
+        LambdaEnvironment.ANALYTICS_BUCKET_ATHENA_PATH
+      );
 
       const fromDate = DateUtils.parseIso(input.from);
       const toDate = DateUtils.parseIso(input.to);
@@ -267,7 +280,10 @@ export function getUsersGroupedByStatForPeriod(trpcInstance: TrpcInstance) {
 
       if (input.filter && Object.keys(input.filter).length === 0) input.filter = undefined;
 
-      const athenaPageViews = new AthenaPageViews();
+      const athenaPageViews = new AthenaPageViews(
+        LambdaEnvironment.ANALYTICS_GLUE_DB_NAME,
+        LambdaEnvironment.ANALYTICS_BUCKET_ATHENA_PATH
+      );
 
       const fromDate = DateUtils.parseIso(input.from);
       const toDate = DateUtils.parseIso(input.to);

--- a/src/src/backend/cron-vacuum/environment.ts
+++ b/src/src/backend/cron-vacuum/environment.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+
+export class LambdaEnvironment {
+  static AWS_REGION: string;
+  static ENVIRONMENT: string;
+  static VERSION: string;
+  static TIMEOUT: number;
+  static LOG_LEVEL: string;
+  static TRACE_ID?: string;
+
+  static ANALYTICS_BUCKET: string;
+  static ANALYTICS_BUCKET_ATHENA_PATH: string; /* Constructed from ANALYTICS_BUCKET on initialization */
+  static ANALYTICS_GLUE_DB_NAME: string;
+  static SITES: string[];
+
+  static init() {
+    const schema = z.object({
+      AWS_REGION: z.string(),
+      ENVIRONMENT: z.string(),
+      VERSION: z.string(),
+      TIMEOUT: z.string().transform((v) => Number(v)),
+      LOG_LEVEL: z.string(),
+
+      ANALYTICS_BUCKET: z.string(),
+      ANALYTICS_GLUE_DB_NAME: z.string(),
+      SITES: z.string().transform((v) => JSON.parse(v) as string[]),
+
+      FIREHOSE_PAGE_VIEWS_NAME: z.string(),
+      FIREHOSE_EVENTS_NAME: z.string(),
+    });
+    const parsed = schema.safeParse(process.env);
+
+    if (!parsed.success) {
+      console.error(parsed.error);
+      throw new Error('Environment Variable Parse Error');
+    }
+
+    for (const key in parsed.data) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore we know this is safe
+      this[key] = parsed.data[key];
+    }
+
+    this.ANALYTICS_BUCKET_ATHENA_PATH = 's3://' + this.ANALYTICS_BUCKET + '/athena-results';
+  }
+}

--- a/src/src/backend/cron-vacuum/index.ts
+++ b/src/src/backend/cron-vacuum/index.ts
@@ -1,0 +1,91 @@
+import { ScheduledEvent, Context } from 'aws-lambda';
+import { LambdaLog } from '@backend/lib/utils/lambda_logger';
+import { LambdaEnvironment } from '@backend/cron-vacuum/environment';
+import { AuditLog } from '@backend/lib/models/audit_log';
+import { v4 as uuidv4 } from 'uuid';
+import { DateUtils } from '@backend/lib/utils/date_utils';
+import { S3PageViews } from '@backend/lib/dal/s3/page_views';
+import { AthenaPageViews } from '@backend/lib/dal/athena/page_views';
+
+/* Lazy loaded variables */
+let initialized = false;
+export const handler = async (event: ScheduledEvent, context: Context): Promise<true> => {
+  // console.log("EVENT", event);
+  const logger = new LambdaLog();
+  const shouldInitialize = !initialized || process.env.TESTING_LOCAL_RE_INIT === 'true';
+  if (shouldInitialize) {
+    LambdaEnvironment.init();
+    logger.init(LambdaEnvironment.ENVIRONMENT);
+    initialized = true;
+  }
+
+  LambdaEnvironment.TRACE_ID = context.awsRequestId;
+  logger.start(LambdaEnvironment.LOG_LEVEL, LambdaEnvironment.TRACE_ID);
+  // logger.info('Init', event);
+
+  const audit: AuditLog = {
+    app_version: LambdaEnvironment.VERSION,
+    audit_log_id: uuidv4(),
+    trace_id: LambdaEnvironment.TRACE_ID,
+    created_at: DateUtils.stringifyIso(DateUtils.now()),
+    environment: LambdaEnvironment.ENVIRONMENT,
+    meta: '',
+    origin: 'swa/cron-vacuum',
+    run_time: 0,
+    success: true,
+    type: 'cron',
+  };
+
+  try {
+    const pageViewBucket = new S3PageViews(LambdaEnvironment.ANALYTICS_BUCKET);
+    const athenaPageViews = new AthenaPageViews(
+      LambdaEnvironment.ANALYTICS_GLUE_DB_NAME,
+      LambdaEnvironment.ANALYTICS_BUCKET_ATHENA_PATH
+    );
+
+    /* Always rollup the previous day (for now) */
+    const previousDayDate = DateUtils.stringifyFormat(DateUtils.addDays(DateUtils.now(), -1), 'yyyy-MM-dd');
+
+    for (const site of LambdaEnvironment.SITES) {
+      const rawFiles = await pageViewBucket.getAllSiteDateFiles(site, previousDayDate);
+      if (!rawFiles.length) {
+        logger.info('No files to rollup', site, previousDayDate);
+        continue;
+      }
+
+      logger.info('Starting rollup', site, previousDayDate, rawFiles.length);
+      await athenaPageViews.rollupPageViews(LambdaEnvironment.ANALYTICS_BUCKET, site, previousDayDate);
+
+      /* Get all files again, only if there are more files than before we started does it mean the rollup was successful
+       * Considering that the rollup runs on the previous days data, nothing can be written to it via the Firehose
+       * under normal circumstances. Therefore, this is thus a safe assumption for data protection , preventing data
+       * deletion if the rollup failed. This is just extra safety as the CTAS query throws an error on failure */
+      const allFilesPostRollup = await pageViewBucket.getAllSiteDateFiles(site, previousDayDate);
+      if (allFilesPostRollup.length === rawFiles.length) {
+        logger.error('Rollup failed ', site, previousDayDate);
+        continue;
+      }
+
+      logger.info('Deleting all raw files', rawFiles.length);
+      await pageViewBucket.deleteAllObjects(rawFiles.map((f) => f.key));
+    }
+
+    audit.success = true;
+  } catch (err) {
+    /* Should ideally never happen, the tRPC Lambda Handler will catch any `throw new Error(...)` and still
+     * return a response that has status code 500. This is just to cover all the basis. */
+    if (err instanceof Error) {
+      logger.error(err);
+      audit.success = false;
+      audit.status_description = err.message;
+      audit.meta = JSON.stringify(err.message);
+    } else {
+      throw new Error('Error is unknown', { cause: err });
+    }
+  } finally {
+    audit.run_time = LambdaEnvironment.TIMEOUT * 1000 - context.getRemainingTimeInMillis();
+    logger.audit(audit);
+  }
+
+  return true;
+};

--- a/src/src/backend/lib/dal/s3/page_views.ts
+++ b/src/src/backend/lib/dal/s3/page_views.ts
@@ -1,0 +1,18 @@
+import { getS3Client } from '@backend/lib/utils/lazy_aws';
+import { S3Base } from '@backend/lib/utils/s3_base';
+
+export class S3PageViews extends S3Base {
+  constructor(analyticsBucket: string) {
+    const s3Client = getS3Client();
+    super(s3Client, analyticsBucket);
+  }
+
+  sitePageViewPath(site: string, date: string) {
+    return `page_views/site=${site}/page_opened_at_date=${date}`;
+  }
+
+  public async getAllSiteDateFiles(site: string, date: string) {
+    const siteDatePrefix = this.sitePageViewPath(site, date);
+    return this.getAllObjects(siteDatePrefix);
+  }
+}

--- a/src/src/backend/lib/models/audit_log.ts
+++ b/src/src/backend/lib/models/audit_log.ts
@@ -18,7 +18,7 @@ export type AuditLog = {
   origin: string;
   origin_path?: string;
   origin_method?: string;
-  type: 'api';
+  type: 'api' | 'cron';
   meta: string;
   created_at: string;
   run_time: number;

--- a/src/src/backend/lib/utils/athena_base.ts
+++ b/src/src/backend/lib/utils/athena_base.ts
@@ -38,7 +38,7 @@ export class AthenaBase {
     };
   }
 
-  async query(
+  protected async query(
     query: string,
     limit?: number,
     queryExecutionId?: string,

--- a/src/src/backend/lib/utils/s3_base.ts
+++ b/src/src/backend/lib/utils/s3_base.ts
@@ -1,0 +1,56 @@
+import { DeleteObjectCommand, ListObjectsV2Command, ListObjectsV2CommandOutput, S3Client } from '@aws-sdk/client-s3';
+import pLimit from 'p-limit';
+
+export class S3Base {
+  protected readonly s3Client: S3Client;
+  protected readonly bucketName: string;
+  constructor(s3Client: S3Client, bucketName: string) {
+    this.s3Client = s3Client;
+    this.bucketName = bucketName;
+  }
+
+  protected async getAllObjects(prefix = '') {
+    let allObjects: { key: string }[] = [];
+    let continuationToken;
+    do {
+      const response: ListObjectsV2CommandOutput = await this.s3Client.send(
+        new ListObjectsV2Command({
+          Bucket: this.bucketName,
+          Prefix: prefix,
+          ContinuationToken: continuationToken,
+        })
+      );
+      const objects = response.Contents || [];
+
+      allObjects = allObjects.concat(
+        objects.map((object) => {
+          return {
+            key: object.Key || '',
+          };
+        })
+      );
+      continuationToken = response.NextContinuationToken;
+    } while (continuationToken);
+
+    return allObjects;
+  }
+
+  public async deleteAllObjects(keys: string[], concurrency = 100) {
+    const limit = pLimit(concurrency);
+    const promises = [];
+
+    for (const key of keys) {
+      promises.push(
+        limit(() => {
+          this.s3Client.send(
+            new DeleteObjectCommand({
+              Bucket: this.bucketName,
+              Key: key,
+            })
+          );
+        })
+      );
+    }
+    await Promise.all(promises);
+  }
+}

--- a/src/src/tests/backend/cron-vacuum/index.ts
+++ b/src/src/tests/backend/cron-vacuum/index.ts
@@ -1,0 +1,46 @@
+import '@tests/environment-hoist';
+import { handler } from '@backend/cron-vacuum';
+import { TestConfig } from '../../../test-config';
+import { apiGwContext, setEnvVariables, TEST_TYPE } from '@tests/helpers';
+import { expect } from 'chai';
+import { ScheduledEvent } from 'aws-lambda';
+
+const ECHO_TEST_OUTPUTS = true;
+const TimeOut = 60;
+// Set in environment-hoist.ts
+// process.env.TEST_TYPE = TEST_TYPE.UNIT;
+// process.env.TEST_TYPE = TEST_TYPE.E2E;
+
+describe('Cron - Vacuum', function () {
+  before(async function () {
+    console.log('TEST_TYPE', process.env.TEST_TYPE);
+  });
+
+  it('Run', async function () {
+    this.timeout(TimeOut * 1000);
+
+    if (process.env.TEST_TYPE === TEST_TYPE.E2E) {
+      console.log('Skipping E2E test');
+      return;
+    }
+
+    const context = apiGwContext();
+    const event: ScheduledEvent = {
+      version: '0',
+      id: '0',
+      'detail-type': 'Scheduled Event',
+      source: 'aws.events',
+      account: '0',
+      time: '1970-01-01T00:00:00Z',
+      region: 'eu-west-1',
+      resources: ['0'],
+      detail: {},
+    };
+
+    setEnvVariables(TestConfig.env);
+    const resp = await handler(event, context);
+    ECHO_TEST_OUTPUTS && console.log(resp);
+
+    expect(resp).to.eq(true);
+  });
+});


### PR DESCRIPTION
The lambda function runs at 1 hour past midnight UTC. At this point, the Firehose is done writing for the previous day and no new data will be written. The function is idempotent and will delete the raw files after doing the rollup only if it is successful. 

During the test, it does an incredible job at rolling up. 

BEFORE: 
S3 Objects (388)
Input rows: 650
Input bytes: 181.34 KB
Output rows: 148
Output bytes: 37.37 KB

AFTER:
**S3 Objects (4)**
Input rows: 148
Input bytes: 33.73 KB
Output rows: 148
Output bytes: 37.26 KB

The important part is the almost 100x reduction in S3 file count. This will decrease the amount of files that Athena has to scan by magnitudes, which means big savings to gain from this rollup. 
