### PR TITLE
feat: Static anomaly detection for pr

### DIFF
--- a/application/src/backend/cron-anomaly-detection/environment.ts
+++ b/application/src/backend/cron-anomaly-detection/environment.ts
@@ -16,6 +16,7 @@ export class LambdaEnvironment {
   static EVALUATION_WINDOW: number;
   static BREACHING_MULTIPLIER: number;
   static EVENT_BRIDGE_SOURCE: string;
+  static MINIMUM_VIEWS: number;
 
   static init() {
     const schema = z.object({
@@ -32,6 +33,7 @@ export class LambdaEnvironment {
       EVALUATION_WINDOW: z.string().transform((v) => Number(v)),
       BREACHING_MULTIPLIER: z.string().transform((v) => Number(v)),
       EVENT_BRIDGE_SOURCE: z.string(),
+      MINIMUM_VIEWS: z.string().transform((v) => Number(v)),
     });
     const parsed = schema.safeParse(process.env);
 

--- a/application/src/backend/cron-anomaly-detection/stat_functions.ts
+++ b/application/src/backend/cron-anomaly-detection/stat_functions.ts
@@ -168,7 +168,8 @@ export function predict(data: CleanedData, seasonLength: number, predictedBreach
   const breachingThreshold = predicted * predictedBreachingMultiplier;
   /* Use the `data.latest.record` instead of `data.trainingDataViews[data.trainingDataViews.length-1]` because the
    * latter has clamped values */
-  const breachingLatest = latestRecord.views > breachingThreshold;
+  const breachingLatest = latestRecord.views > LambdaEnvironment.MINIMUM_VIEWS &&
+    latestRecord.views > breachingThreshold;
   logger.debug('Prediction', {
     Latest: latestRecord,
     Predicted: predicted,

--- a/application/src/backend/cron-anomaly-detection/stat_functions.ts
+++ b/application/src/backend/cron-anomaly-detection/stat_functions.ts
@@ -168,8 +168,8 @@ export function predict(data: CleanedData, seasonLength: number, predictedBreach
   const breachingThreshold = predicted * predictedBreachingMultiplier;
   /* Use the `data.latest.record` instead of `data.trainingDataViews[data.trainingDataViews.length-1]` because the
    * latter has clamped values */
-  const breachingLatest = latestRecord.views > LambdaEnvironment.MINIMUM_VIEWS &&
-    latestRecord.views > breachingThreshold;
+  const breachingLatest =
+    latestRecord.views > LambdaEnvironment.MINIMUM_VIEWS && latestRecord.views > breachingThreshold;
   logger.debug('Prediction', {
     Latest: latestRecord,
     Predicted: predicted,

--- a/docs/ANOMALY_DETECTION.md
+++ b/docs/ANOMALY_DETECTION.md
@@ -25,7 +25,7 @@ Two important environment variables are used to configure the detection:
    The actual value of 100 is less than the breaching threshold of 160, so the evaluation is not marked as breaching.
    If the actual value was say 200, then it would be more than the breaching threshold and the evaluation would be
    marked as breaching.
-- `MINIMUM_VIEWS` This is a minimum value, below which any other values will not be considered to be breaching the threshold.  It defaults to 0.  As an example - if you have a spike from 1 view over several hours to 100 views in an hour, even for multiple hours, that would normally set off the alarm.  If `MINIMUM_VIEWS` is set to 1000, though, it'll be ignored.
+- `MINIMUM_VIEWS` The minimum number of views before an evaluation is considered breached. Continuing with the example above, if the `Minimum Views` parameter is specified as 101, which is less than the actual view of 100, then the predicted value, breaching multiplier, and the breaching threshold are irrelevant as the evaluation will not be able to transition into the breaching state.
 
 ### Logic
 

--- a/docs/ANOMALY_DETECTION.md
+++ b/docs/ANOMALY_DETECTION.md
@@ -25,6 +25,7 @@ Two important environment variables are used to configure the detection:
    The actual value of 100 is less than the breaching threshold of 160, so the evaluation is not marked as breaching.
    If the actual value was say 200, then it would be more than the breaching threshold and the evaluation would be
    marked as breaching.
+- `MINIMUM_VIEWS` This is a minimum value, below which any other values will not be considered to be breaching the threshold.  It defaults to 0.  As an example - if you have a spike from 1 view over several hours to 100 views in an hour, even for multiple hours, that would normally set off the alarm.  If `MINIMUM_VIEWS` is set to 1000, though, it'll be ignored.
 
 ### Logic
 

--- a/infra/src/backend.ts
+++ b/infra/src/backend.ts
@@ -349,6 +349,7 @@ export function backend(
         EVALUATION_WINDOW: props.anomaly.detection.evaluationWindow!.toString(),
         BREACHING_MULTIPLIER: props.anomaly.detection.predictedBreachingMultiplier!.toString(),
         EVENT_BRIDGE_SOURCE: eventBridgeSource,
+        MINIMUM_VIEWS: props.anomaly.detection.minimumViews!.toString(),
       },
       /* The lambda is NOT idempotent */
       retryAttempts: 0,

--- a/infra/src/index.ts
+++ b/infra/src/index.ts
@@ -180,6 +180,12 @@ export interface AnomalyDetectionProps {
    * @default 2
    */
   readonly predictedBreachingMultiplier?: number;
+
+  /**
+   * The minimum threshold views before allowing breaching.
+   * @default 0
+   */
+  readonly minimumViews?: number;
 }
 
 export interface AnomalyAlertProps {
@@ -210,7 +216,8 @@ export interface AnomalyProps {
    * Optional, if specified overrides the default properties
    * @default ```{
    *   evaluationWindow: 2,
-   *   predictedBreachingMultiplier: 2
+   *   predictedBreachingMultiplier: 2,
+   *   minimumViews: 0
    * }```
    */
   readonly detection?: AnomalyDetectionProps;
@@ -346,6 +353,7 @@ export class Swa extends Construct {
         detection: {
           evaluationWindow: 2,
           predictedBreachingMultiplier: 2,
+          minimumViews: 0,
         },
         alert: {
           onAlarm: true,

--- a/infra/src/index.ts
+++ b/infra/src/index.ts
@@ -182,7 +182,7 @@ export interface AnomalyDetectionProps {
   readonly predictedBreachingMultiplier?: number;
 
   /**
-   * The minimum threshold views before allowing breaching.
+   * The minimum number of views before an evaluation is considered breached.
    * @default 0
    */
   readonly minimumViews?: number;

--- a/tests/test-config.ts
+++ b/tests/test-config.ts
@@ -31,6 +31,7 @@ export type TestConfig = {
     EVALUATION_WINDOW: string;
     BREACHING_MULTIPLIER: string;
     EVENT_BRIDGE_SOURCE: string;
+    MINIMUM_VIEWS: string;
 
     ALERT_TOPIC_ARN: string;
     ALERT_ON_ALARM: string;
@@ -83,6 +84,7 @@ export const TestConfig: TestConfig = {
     EVALUATION_WINDOW: '2',
     BREACHING_MULTIPLIER: '2',
     EVENT_BRIDGE_SOURCE: 'swa-demo-prod',
+    MINIMUM_VIEWS: '0',
 
     ALERT_TOPIC_ARN: 'arn:aws:sns:eu-west-1:123456789:your-topic-name',
     ALERT_ON_ALARM: 'true',


### PR DESCRIPTION
This does not directly address issue #75, but does address some comments there.

This PR adds a minimumViews parameter which must be exceeded before the anomaly detection considers a set of views to be an anomaly.  The default is 0, so by default this is off.  An example is provided in the anomaly detection documentation.